### PR TITLE
Update carbon version to avoid composer conflicts with newer projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php-http/client-implementation": "^1.0.0",
         "php-http/message": "^1.0",
         "firebase/php-jwt": "^3.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^1.0||^2.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php-http/client-implementation": "^1.0.0",
         "php-http/message": "^1.0",
         "firebase/php-jwt": "^3.0",
-        "nesbot/carbon": "^1.0"
+        "nesbot/carbon": "^2.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",


### PR DESCRIPTION
Hi,

Problem:
the composer required ^1.0 Carbon version causes conflict errors when SPOIL library is integrated inside new projects, like Laravel 6.0.

Solution:
change to a newer Carbon version(2.x). I tested site, file and folder creation with the new Carbon version. It is working fine.

Thanks.